### PR TITLE
Adds README files for .repo tools

### DIFF
--- a/.repo/README.md
+++ b/.repo/README.md
@@ -1,0 +1,37 @@
+# .repo
+
+이 디렉토리는 GitHub 템플릿 레포지토리 초기화 및 관리를 위한 도구들을 포함하고 있습니다.
+
+## 폴더 구조
+
+### .repo/githook
+
+Git 커밋 메시지 규칙을 강제하고 코드 품질을 유지하기 위한 Git hooks 구성 파일들을 포함합니다.
+
+- **Husky**: Git hooks를 쉽게 설정하고 관리할 수 있도록 도와줍니다.
+- **Commitlint**: 커밋 메시지가 [Conventional Commits](https://www.conventionalcommits.org/) 규칙을 따르도록 강제합니다.
+
+설정 및 사용 방법은 해당 폴더의 README를 참조하세요.
+
+### .repo/git
+
+GitHub 저장소 관리 자동화 도구를 제공합니다.
+
+- **브랜치 보호 설정**: 지정된 브랜치에 대한 보호 규칙을 자동으로 설정합니다.
+- **자동 브랜치 삭제**: PR 병합 후 소스 브랜치를 자동으로 삭제하도록 설정합니다.
+- **기타 GitHub 관련 자동화 도구**: 저장소 관리에 필요한 다양한 기능을 제공합니다.
+
+각 도구의 상세 사용법은 해당 폴더의 문서를 참조하세요.
+
+## 사용 방법
+
+각 폴더 내의 README 파일과 스크립트 상단 주석을 참조하여 필요한 기능을 사용하세요.
+
+## 기타
+
+### 머지된 로컬 브랜치 정리
+
+```bash
+# ~/.zshrc
+alias cleanb='git branch --merged | grep -Ev "(^\*|^\+|master|develop|staging|release)" | xargs --no-run-if-empty git branch -d'
+```

--- a/.repo/githook/README.md
+++ b/.repo/githook/README.md
@@ -1,0 +1,86 @@
+# Git Hooks 설정
+
+이 디렉토리는 Git 커밋 메시지 규칙을 강제하고 코드 품질을 유지하기 위한 Git hooks 구성 파일들을 포함하고 있습니다.
+
+## 주요 기능
+
+- **Husky**: Git hooks를 쉽게 설정하고 관리
+- **Commitlint**: 커밋 메시지가 [Conventional Commits](https://www.conventionalcommits.org/) 규칙을 준수하도록 검증
+
+## Getting Started
+
+### 1. 패키지 설치
+
+```bash
+cd .repo/githook
+npm install
+```
+
+### 2. Husky 설정
+
+루트 디렉토리(프로젝트 최상위)에서 다음 명령어를 실행합니다:
+
+```bash
+# 루트 디렉토리에서 실행
+cd .repo/githook
+npx husky install ../../.husky
+```
+
+### 3. Commit-msg Hook 설정
+
+```bash
+# commit-msg 훅 설정
+npx husky add ../../.husky/commit-msg "npx --no -- commitlint --edit $1"
+```
+
+## 커밋 메시지 규칙
+
+이 프로젝트는 [Conventional Commits](https://www.conventionalcommits.org/) 규칙을 따릅니다:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### 타입 목록
+
+- `feat`: 새로운 기능 추가
+- `fix`: 버그 수정
+- `docs`: 문서 변경
+- `style`: 코드 포맷팅, 세미콜론 누락 등 (코드 변경 없음)
+- `refactor`: 코드 리팩토링
+- `test`: 테스트 코드 추가 또는 수정
+- `chore`: 빌드 프로세스, 패키지 매니저 설정 등 변경 (소스 코드 변경 없음)
+
+### 예시
+
+```
+feat(auth): 로그인 기능 추가
+
+사용자 로그인 API 및 폼 구현
+
+Resolves: #123
+```
+
+## 문제 해결
+
+### type="module" 오류
+
+commitlint.config.js에서 ES 모듈 구문을 사용하는 경우, package.json에 다음을 추가합니다:
+
+```json
+{
+  "type": "module"
+}
+```
+
+### Husky가 작동하지 않을 때
+
+Git hooks 디렉토리 권한을 확인합니다:
+
+```bash
+chmod -R +x .husky
+```

--- a/.repo/github/README.md
+++ b/.repo/github/README.md
@@ -1,0 +1,95 @@
+# GitHub 저장소 관리 도구
+
+이 디렉토리는 GitHub 저장소 관리와 관련된 자동화 스크립트와 설정 파일을 포함하고 있습니다.
+
+## 주요 기능
+
+- **브랜치 보호 설정**: 지정된 브랜치에 대한 보호 규칙을 자동으로 설정
+- **자동 브랜치 삭제**: PR 병합 후 소스 브랜치를 자동으로 삭제하도록 설정
+- **기타 GitHub 관련 자동화 도구**: 저장소 관리에 필요한 다양한 기능 제공
+
+## Getting Started
+
+### 1. 패키지 설치
+
+```bash
+cd .repo/github
+npm install
+```
+
+### 2. 환경 변수 설정
+
+`.env` 파일을 생성하고 필요한 환경 변수를 설정합니다:
+
+```bash
+# .env 파일 생성
+cat > .env << EOL
+# GitHub 개인 액세스 토큰 (PAT)
+GITHUB_TOKEN=ghp_your_personal_access_token
+
+# 보호할 브랜치 목록 (쉼표로 구분)
+PROTECTED_BRANCHES=main,develop,staging,release
+EOL
+```
+
+GitHub Personal Access Token은 다음 스코프 권한이 필요합니다:
+- `repo`: 저장소 관리 권한
+- `admin:org` (조직 레포지토리의 경우)
+
+### 3. 브랜치 보호 규칙 설정
+
+```bash
+# 환경 변수에 명시된 브랜치들에 보호 규칙 적용
+npm run protect
+```
+
+이 명령은 다음 작업을 수행합니다:
+- 존재하지 않는 브랜치는 자동 생성
+- PR에 최소 1개의 승인이 필요하도록 설정
+- 관리자(owner)는 제한 없이 변경할 수 있도록 설정
+
+### 4. PR 병합 후 브랜치 자동 삭제 설정
+
+```bash
+# PR 병합 시 소스 브랜치 자동 삭제 옵션 활성화
+npm run auto-delete
+```
+
+### 5. 모든 설정 한 번에 적용
+
+```bash
+# 브랜치 보호 규칙 및 자동 삭제 옵션 모두 설정
+npm run start all
+```
+
+## 고급 기능
+
+### 브랜치 자동 삭제 상태 확인
+
+```bash
+npm run check-auto-delete
+```
+
+### 도움말 보기
+
+```bash
+npm run start help
+```
+
+## API 문서
+
+모든 스크립트는 TypeScript로 작성되었으며, 주요 기능들을 모듈화하여 제공합니다:
+
+- `protectBranches()`: 브랜치 보호 규칙 설정
+- `enableAutoDeleteMergedBranches()`: PR 병합 시 브랜치 자동 삭제 옵션 활성화
+- `checkAutoDeleteMergedBranchesStatus()`: 자동 삭제 옵션 상태 확인
+
+## 문제 해결
+
+### 권한 오류
+
+권한 오류가 발생하는 경우, GitHub 토큰에 적절한 권한이 부여되었는지 확인하세요.
+
+### 브랜치 보호 규칙이 적용되지 않는 경우
+
+저장소 소유자 또는 관리자 권한이 있는지 확인하세요. 브랜치 보호 규칙을 설정하려면 관리자 권한이 필요합니다.


### PR DESCRIPTION
Adds README files to the `.repo`, `.repo/githook`, and `.repo/github` directories.

These README files:

- Provide documentation for setting up and using the tools within each directory.
- Explain the purpose and functionality of each tool, including Git hooks management and GitHub repository automation.
- Include instructions on installation, configuration, and usage examples.