### PR TITLE
Updates local branch cleaning alias

### DIFF
--- a/.repo/README.md
+++ b/.repo/README.md
@@ -29,9 +29,9 @@ GitHub 저장소 관리 자동화 도구를 제공합니다.
 
 ## 기타
 
-### 머지된 로컬 브랜치 정리
+### 로컬 브랜치 정리 (주의: 병합 안된 브랜치도 삭제)
 
 ```bash
 # ~/.zshrc
-alias cleanb='git branch --merged | grep -Ev "(^\*|^\+|master|develop|staging|release)" | xargs --no-run-if-empty git branch -d'
+alias cleanb='git branch | grep -Ev "(^\*|master|develop|staging|release)" | xargs --no-run-if-empty git branch -D'
 ```


### PR DESCRIPTION
완전히 병합되지 않은 브랜치를 포함한 로컬 브랜치를 제거하도록 `cleanb` 별칭을 업데이트합니다.

- 강제 삭제를 위해 `git branch -D`를 사용하도록 별칭을 수정합니다.
- 병합되지 않은 브랜치 삭제로 인한 데이터 손실 가능성에 대한 경고를 추가합니다.